### PR TITLE
{% cache %} block wrapping Rails.cache.fetch (master)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (3.2.19)
+    activesupport (3.2.21)
       i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     diff-lcs (1.2.5)

--- a/README.md
+++ b/README.md
@@ -67,6 +67,47 @@ It behaves exactly like the default liquid **for** but with the exception of hav
 
     Project #1, Project #2, Project #3
 
+### cache ###
+
+#### Description ####
+
+Wrap `Rails.cache.fetch` with a `{% cache %}` liquid tag. Useful for
+partial page caching above and beyond existing LocomotiveCMS caching
+features. For example, around content entry loops rendering snippets.
+
+#### Usage ####
+
+Wrap blocks of code in your template with the `{% cache %}` tag, sending in 
+one or more keys to be used. Keys can be either strings or page-level variables which will be evaluated.
+Send in multiple keys as comma-separated list.
+
+For example:
+
+    {% assign variable = 'key2' %}
+    {% cache 'key1', variable, 'key3' %}
+      {% for example in contents.examples %}
+        {% include 'example_item' with example %}
+      {% endfor %}
+    {% endcache %}
+
+Within your engine (not wagon), this will make a call to
+
+    Rails.cache.fetch("locomotive/key1/key2/key3")
+
+If there is a cache hit, the found content will be returned and rendered.
+If there is a miss, the block inside the `{% cache %}` tag will be executed,
+and the result will be written to the cache before the content is
+rendered.
+
+Your LocomotiveCMS engine must be configured to use a
+memcache-equivalent datastore through the dalli gem in order for
+this to work. Otherwise it will count as a cache miss every time. Check your Rails logs to
+watch cache misses vs. hits as well as composite keys being used.
+
+**Note:** Cache must currently be manually reset on your engine through
+`irb` by executing `Rails.cache.clear` after any changes to contents.
+
+
 ### send_email
 
 #### Description

--- a/lib/locomotive/liquid_extensions/tags/cacher.rb
+++ b/lib/locomotive/liquid_extensions/tags/cacher.rb
@@ -1,0 +1,77 @@
+module Locomotive
+  module LiquidExtensions
+    module Tags
+
+      class Cacher < Solid::Block
+
+        SEPARATOR = "/"
+        ERROR_CACHE_KEY_REQUIRED = "Cache key required"
+        CACHE_KEY_ROOT_NAMESPACE = "locomotive"
+
+        attr_accessor :key
+
+        def initialize(tag_name, arguments, tokens, context)
+          # little hack to make it work with Liquid 2.6.2
+          @options = context
+
+          super
+
+          @context  = context
+        end
+
+        def display(*values)
+          self.key = cache_key(values)
+          return cache_mechanism.fetch(self.key) do
+            log("render", "cache miss: fetching [#{self.key}]")
+            yield
+          end
+        end
+
+      protected
+
+        def cache_key(user_keys)
+          # block must contain a key
+          raise ERROR_CACHE_KEY_REQUIRED if user_keys.empty?
+
+          # start all keys with namespace
+          key_parts = [CACHE_KEY_ROOT_NAMESPACE]
+
+          # add each user part after cleaning
+          user_keys.each do |key|
+            key_parts << clean(key) unless key.blank?
+          end
+
+          # join composite key parts into single key string using separator
+          return key_parts.join(SEPARATOR)
+        end
+
+        def clean(s)
+          # remove quotes and surrounding whitespace
+          return remove_quotes(s).strip
+        end
+
+        def remove_quotes(string)
+          # more leading and trailling quotes (simple or double)
+          string.gsub(/^([\/'"]+)/, '').gsub(/([\/'"]+)$/, '')
+        end
+
+        def cache_mechanism
+          if Gem::Specification::find_all_by_name('rails').any?
+            return Rails.cache
+          else
+            # return a generic cache object -- WILL NOT ACTUALLY CACHE
+            return ActiveSupport::Cache.lookup_store(:memory_store)
+          end
+        end
+
+        def log(method, s)
+          puts "Locomotive::LiquidExtensions::Tags::Cacher##{method}\t#{s}" if ENV["RAILS_ENV"] == "development"
+        end
+
+      end
+
+      ::Liquid::Template.register_tag('cache', Cacher)
+
+    end
+  end
+end

--- a/spec/locomotive/liquid_extensions/tags/cacher_spec.rb
+++ b/spec/locomotive/liquid_extensions/tags/cacher_spec.rb
@@ -1,0 +1,147 @@
+require 'spec_helper'
+
+describe Locomotive::LiquidExtensions::Tags::Cacher do
+
+  let(:tag_class)   { Locomotive::LiquidExtensions::Tags::Cacher }
+  let(:key_prefix)  { tag_class::CACHE_KEY_ROOT_NAMESPACE }
+  let(:arguments)   { "'test-key'" }
+  let(:markup)      { "" }
+  let(:tokens)      { [markup, '{% endcache %}', 'outside'] }
+  let(:assigns)     { {} }
+  let(:environment) { {} }
+  let(:context)     { Liquid::Context.new(environment, assigns, { logger: CustomLogger }) }
+
+  let(:tag) { tag_class.new('cache', arguments, tokens, {}) }
+  subject   { tag.render(context) }
+
+  describe "baseline markup" do
+    it "should be a string" do
+      expect(subject).to be_a String
+    end
+
+    it "should be a blank string" do
+      expect(subject).to eq ''
+    end
+  end
+
+  context "when contains markup" do
+    let(:markup) { "<div>This is a cache fragment</div>" }
+    it "should return what it's given" do
+      expect(subject).to eq markup
+    end
+  end
+
+  context "nil key" do
+    let(:arguments) { nil }
+    it "should raise an error" do
+      expect { subject }.to raise_error Locomotive::LiquidExtensions::Tags::Cacher::ERROR_CACHE_KEY_REQUIRED
+    end
+  end
+
+  context "blank key" do
+    let(:arguments) { "" }
+    it "should raise an error" do
+      expect { subject }.to raise_error Locomotive::LiquidExtensions::Tags::Cacher::ERROR_CACHE_KEY_REQUIRED
+    end
+  end
+
+  context "cache key" do
+    before(:each) do
+      # force render
+      subject
+    end
+
+    context "separators" do
+      context "key with dash" do
+        let(:arguments) { "'test-key'" }
+        it "should use the given key since it's valid" do
+          expect(tag.key).to eq testkey("test-key")
+        end
+      end
+
+      context "key with underscore" do
+        let(:arguments) { "'test_key'" }
+        it "should use the given key since it's valid" do
+          expect(tag.key).to eq testkey("test_key")
+        end
+      end
+
+      context "key with forward slash" do
+        let(:arguments) { "'test/key'" }
+        it "should use the given key since it's valid" do
+          expect(tag.key).to eq testkey("test/key")
+        end
+      end
+
+      context "key with backward slash" do
+        let(:arguments) { "'test\\key'" }
+        it "should use the given key since it's valid" do
+          expect(tag.key).to eq testkey("test\\key")
+        end
+      end
+    end
+
+    context "cleaning" do
+      context "key with single quote" do
+        let(:arguments) { "'single-quote-key'" }
+        it "should remove single quote" do
+          expect(tag.key).to eq testkey("single-quote-key")
+        end
+      end
+
+      context "key with double quote" do
+        let(:arguments) { '"double-quote-key"' }
+        it "should remove double quote" do
+          expect(tag.key).to eq testkey("double-quote-key")
+        end
+      end
+
+      context "key wrapped by slashes" do
+        let(:arguments) { "'/slash-key/'" }
+        it "should remove the slashes" do
+          expect(tag.key).to eq testkey("slash-key")
+        end
+      end
+
+      context "key with whitespace around it" do
+        let(:arguments) { "'   whitespace-key   '" }
+        it "should remove the whitespace" do
+          expect(tag.key).to eq testkey("whitespace-key")
+        end
+      end
+    end
+
+    context "sequence" do
+      let(:arguments) { "'one', 'two', 'three'" }
+      it "should combine into single key" do
+        expect(tag.key).to eq testkey("one/two/three")
+      end
+    end
+
+    context "variable in key" do
+      context "variable is entire key" do
+        let(:environment) { { 'foo' => 'bar' } }
+        let(:arguments) { 'foo' }
+        it "should evaluate the variable" do
+          expect(tag.key).to eq testkey("bar")
+        end
+      end
+
+      context "variable in sequence" do
+        let(:environment) { { 'foo' => 'bar' } }
+        let(:arguments) { "'test', foo, 'key'" }
+        it "should evaluate the variable in context" do
+          expect(tag.key).to eq testkey("test/bar/key")
+        end
+      end
+    end
+
+  end
+
+  def testkey(key)
+    return "#{key_prefix}/#{key}"
+  end
+
+end
+
+


### PR DESCRIPTION
Thank you for all of your work on LocomotiveCMS!

This pull request is for a `{% cache %}` liquid block which functions like [Rails fragment caching](http://guides.rubyonrails.org/caching_with_rails.html#fragment-caching). Behind the scenes, it calls `Rails.cache.fetch` which, if `dalli` is configured correctly on the LocomotiveCMS Engine, will make a call to a memcache-like datastore. If it is not configured, it will simply evaluate the block.

I created this to speed up a ["View All" SEO pagination page](http://moz.com/ugc/seo-guide-to-google-webmaster-recommendations-for-pagination) which was looping through many content entries and rendering snippets which resulted in many sequential MongoDB calls. The trade-off to having a single call to render this whole block is needing to manually call `Rails.cache.clear` after a content change. I am sure there is a better way around this!

I have a corresponding `cache-hosting` branch that I will submit a pull request into the `hosting` branch.
